### PR TITLE
feat: add support for `--output` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Laravel Foggy
 
-This package is a Laravel wrapper for Foggy.  
+This package is a Laravel wrapper for Foggy.
+
 Configuration of the plugin can be found at [Foggy's docs](https://github.com/worksome/foggy).
 
 ## Install
@@ -13,17 +14,17 @@ composer require worksome/foggy-laravel
 
 ## Usage
 
-This package adds a new artisan command for running Foggy. Simply type 
+This package adds a new artisan command for running Foggy. Simply type:
 
 ````shell
 php artisan db:dump
 ````
 
-It will by default assume that the Foggy config file, will be in `foggy.json` in the root fo the project.  
+It will by default assume that the Foggy config file, will be in `foggy.json` in the root of the project.  
 A configuration file can be supplied by using `--config` argument.
 
-The artisan command will make the db dump to `stdout`. The best way to parse this to a file is simply to pipe it.
+The artisan command by default will make the database dump to `stdout`. To pass the output to a file, use the `--output` (`-o`) option. 
 
 ```shell
-php artisan db:dump > scrubbedDump.sql
+php artisan db:dump --output scrubbed-dump.sql
 ```

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,10 @@
     "type": "library",
     "require": {
         "php": "^8.2",
-        "worksome/foggy": "^0.6",
+        "illuminate/console": "^10.0 || ^11.0",
         "illuminate/support": "^10.0 || ^11.0",
-        "illuminate/console": "^10.0 || ^11.0"
+        "thecodingmachine/safe": "^2.5",
+        "worksome/foggy": "^0.6"
     },
     "license": "MIT",
     "autoload": {
@@ -20,5 +21,10 @@
                 "Worksome\\FoggyLaravel\\FoggyServiceProvider"
             ]
         }
-    }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/DatabaseDumpCommand.php
+++ b/src/DatabaseDumpCommand.php
@@ -1,45 +1,40 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Worksome\FoggyLaravel;
 
-use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use Safe\Exceptions\JsonException;
+use Symfony\Component\Console\Output\StreamOutput;
 use Worksome\Foggy\DumpProcess;
 
-/**
- * Scrubs the database.
- */
+use function Safe\fopen;
+
 class DatabaseDumpCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'db:dump {--config= : path to a json config file}';
+    /** {@inheritdoc} */
+    protected $signature = 'db:dump {--config= : path to a json config file}
+                                {--o|output= : path to an output file}';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    /** {@inheritdoc} */
     protected $description = 'Dump a scrubbed database.';
 
-    /**
-     * Execute the console command.
-     *
-     * @throws Exception
-     */
     public function handle(): void
     {
-        $configFile = $this->option('config') ?:  $this->getLaravel()->basePath('foggy.json');
+        $configFile = $this->option('config') ?: $this->getLaravel()->basePath('foggy.json');
+
+        $dumpOutput = $this->option('output')
+            ? new StreamOutput(fopen($this->option('output'), 'w'))
+            : $this->getOutput()->getOutput();
+
+        $consoleOutput = $this->option('output') ? $this->getOutput()->getOutput() : null;
 
         $process = new DumpProcess(
             DB::connection()->getDoctrineConnection(),
             $configFile,
-            $this->getOutput()
+            $dumpOutput,
+            $consoleOutput
         );
 
         $process->run();

--- a/src/FoggyServiceProvider.php
+++ b/src/FoggyServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Worksome\FoggyLaravel;
 
 use Illuminate\Support\ServiceProvider;
@@ -10,7 +12,7 @@ class FoggyServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                DatabaseDumpCommand::class
+                DatabaseDumpCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
This adds a new `--output <file>` option to the `db:dump` command which allows for outputting the SQL dump to a file rather than to `stdout`.