### PR TITLE
feat: add support for selecting DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ The artisan command by default will make the database dump to `stdout`. To pass 
 ```shell
 php artisan db:dump --output scrubbed-dump.sql
 ```
+
+Foggy also supports specifying a custom database connection:
+
+```shell
+php artisan db:dump --connection mysql
+```

--- a/src/DatabaseDumpCommand.php
+++ b/src/DatabaseDumpCommand.php
@@ -14,8 +14,9 @@ use function Safe\fopen;
 class DatabaseDumpCommand extends Command
 {
     /** {@inheritdoc} */
-    protected $signature = 'db:dump {--config= : path to a json config file}
-                                {--o|output= : path to an output file}';
+    protected $signature = 'db:dump {--config= : The path to a JSON config file}
+                                {--o|output= : The path to an output file}
+                                {--connection= : The database connection to use}';
 
     /** {@inheritdoc} */
     protected $description = 'Dump a scrubbed database.';
@@ -31,7 +32,7 @@ class DatabaseDumpCommand extends Command
         $consoleOutput = $this->option('output') ? $this->getOutput()->getOutput() : null;
 
         $process = new DumpProcess(
-            DB::connection()->getDoctrineConnection(),
+            DB::connection($this->option('connection'))->getDoctrineConnection(),
             $configFile,
             $dumpOutput,
             $consoleOutput


### PR DESCRIPTION
This adds support for a new `--connection <connection>` option to choose a database connection that should be dumped. This is useful if the application has multiple databases.

For example, if the app has 2 connections named `default` and `auth`, then these could be dumped like:

```shell
// Dump the default connection
php artisan db:dump --config foggy.json

// Dump the auth connection
php artisan db:dump --connection auth --config foggy.auth.json
```