### PR TITLE
feat: add support for quiet output

### DIFF
--- a/src/DatabaseDumpCommand.php
+++ b/src/DatabaseDumpCommand.php
@@ -6,6 +6,8 @@ namespace Worksome\FoggyLaravel;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Worksome\Foggy\DumpProcess;
 
@@ -29,7 +31,11 @@ class DatabaseDumpCommand extends Command
             ? new StreamOutput(fopen($this->option('output'), 'w'))
             : $this->getOutput()->getOutput();
 
-        $consoleOutput = $this->option('output') ? $this->getOutput()->getOutput() : null;
+        $consoleOutput = match (true) {
+            $this->option('output') && $this->option('quiet') => new ConsoleOutput(OutputInterface::VERBOSITY_QUIET),
+            $this->option('output') => $this->getOutput()->getOutput(),
+            default => null,
+        };
 
         $process = new DumpProcess(
             DB::connection($this->option('connection'))->getDoctrineConnection(),


### PR DESCRIPTION
This adds support for using the `--quiet` (`-q`) option with the `--output` option so that no console output is generated.

This is useful when relying on exit codes, or similar.