### PR TITLE
fix: resolve Doctrine on L11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "doctrine/dbal": "*",
         "illuminate/console": "^10.0 || ^11.0",
+        "illuminate/database": "^10.0 | ^11.0",
         "illuminate/support": "^10.0 || ^11.0",
         "thecodingmachine/safe": "^2.5",
         "worksome/foggy": "^0.6"

--- a/src/Concerns/ConnectsToDatabase.php
+++ b/src/Concerns/ConnectsToDatabase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\FoggyLaravel\Concerns;
+
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDO\Connection;
+use InvalidArgumentException;
+use PDO;
+
+trait ConnectsToDatabase
+{
+    public function connect(array $params): DriverConnection
+    {
+        if (! isset($params['pdo']) || ! $params['pdo'] instanceof PDO) {
+            throw new InvalidArgumentException('Laravel requires the "pdo" property to be set and be a PDO instance.');
+        }
+
+        return new Connection($params['pdo']);
+    }
+}

--- a/src/Enums/SupportedDriver.php
+++ b/src/Enums/SupportedDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\FoggyLaravel\Enums;
+
+use Doctrine\DBAL\Driver;
+use Worksome\FoggyLaravel\Concerns\ConnectsToDatabase;
+
+enum SupportedDriver
+{
+    case MySQL;
+    case PostgreSQL;
+    case SQLite;
+    case SqlServer;
+
+    public function driverName(): string
+    {
+        return match ($this) {
+            self::MySQL => 'pdo_mysql',
+            self::PostgreSQL => 'pdo_pgsql',
+            self::SQLite => 'pdo_sqlite',
+            self::SqlServer => 'pdo_sqlsrv',
+        };
+    }
+
+    public function driver(): Driver
+    {
+        return match ($this) {
+            self::MySQL => new class extends Driver\AbstractMySQLDriver
+            {
+                use ConnectsToDatabase;
+            },
+            self::PostgreSQL => new class extends Driver\AbstractPostgreSQLDriver
+            {
+                use ConnectsToDatabase;
+            },
+            self::SQLite => new class extends Driver\AbstractSQLiteDriver
+            {
+                use ConnectsToDatabase;
+            },
+            self::SqlServer => new class extends Driver\AbstractSQLServerDriver
+            {
+                use ConnectsToDatabase;
+            },
+        };
+    }
+}

--- a/tests/Feature/DatabaseDumpCommandTest.php
+++ b/tests/Feature/DatabaseDumpCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\FoggyLaravel\DatabaseDumpCommand;
+
+beforeEach(function () {
+    file_put_contents(base_path('foggy.json'), <<<'JSON'
+    {
+        "database": {
+            "*": {
+                "withData": true
+            }
+        }
+    }
+    JSON
+    );
+});
+
+afterEach(function () {
+    if (file_exists($foggyConfig = base_path('foggy.json'))) {
+        unlink($foggyConfig);
+    }
+});
+
+it('can run the `db:dump` command', function () {
+    $this
+        ->artisan(DatabaseDumpCommand::class)
+        ->expectsOutputToContain('SET NAMES utf8mb4 ;')
+        ->assertOk();
+});


### PR DESCRIPTION
On Laravel 10, it will use `getDoctrineConnection()` to get the connection, on L11 it will use a custom functionality. 👍🏻

I've tested this on both L10 and L11.

I'm not sure if non-MySQL drivers are supported by Foggy itself (see [these lines](https://github.com/worksome/foggy/blob/main/src/Dumper.php#L59-L71) which seem to imply that it's intended only for MySQL / MariaDB), but I haven't dropped support for them. 🤔